### PR TITLE
Update ServerWhitelist.yml

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -28,6 +28,11 @@ GoogleIDs:
     - 1onnt0Yvu18p5V9ZGCGU812WU4KRStuxO # NOISE - TexGen Output
     - 1m5li1DExtyeMYOBqEPjCtx_jrkbXHNog # NOISE - DynDOLOD Output
     
+    # Helidoc65 NOISE Fork files
+    - 1njsamTJxxtvojbJk7PrRHCuoxXoK4m-d # NOISE - xLODGEN Output
+    - 1nlJ4SWCw8-Eox1J8tErS3x4p1yVYGwrz # NOISE - TexGen Output
+    - 1trq-KUEe-F64tm6DUQ2BebT35dTqpzny # NOISE - DynDOLOD Output
+    
     # Lively Noise Fork files
     - 1qSpGlt5foXkp776m0UOb3qHtu1A2Ry_M # LODGen_Output
     - 1UMbI9pI_gvt8z5xB70DGUMw3NSF44Idt # TexGen_Output


### PR DESCRIPTION
ServerWhitelist.yml updated to include Helidoc65 NOISE Fork files for release once updated to #public-modlist in Discord. DoubleDog (Shelb) is aware of this transition.