### PR TITLE
whitelist updates for RGE

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -105,7 +105,7 @@ AllowedPrefixes:
     - https://mega.nz/#!JYgUDCCK!hgUAmavw2NUtYxQf8HfDuIOQNdX7hF_Vwbe8iDc6E0w # DynDOLOD-Scripts.7z For Skyrim VR
     - https://mega.nz/#!14olzQZa!YStuCzNaLC5_r7xKqwRXb5J-dlzs7jFe8WsKqm_f_sk # Wrye Bash Nightly 307.201912272350
     
-    - https://mega.nz/#!9JwlDYjK!ZpxPNRgTb5pMJerwowgP-FZJmca1qZfecnpj-46hwEs # DynDOLOD-DLL-SE.1.5.80.7z
+    - https://mega.nz/#!0VQ3jC7S!VmTf4nIqunv2GL9Zvh7lLWefJnc2kX4ZUWi42mjc6LE # DynDOLOD-DLL-SE.1.5.97.7z
     - https://mega.nz/#!BBpADYpA!gOHRMZv6Ncd3uSLGD2BGE5hVeL6049R4QbpXVQcmC5Y # DynDOLOD-DLL-VR.1.4.15.7z
     - https://mega.nz/#!K4dEAa4S!rrg78Fck-0QL-bcyHt9sPxJOat9ZA5Fau0JJEPiXGvY # Creation Kit 1.5.3
     - https://archive.org/download/Wyrmstooth1.17B/Wyrmstooth%201.17B.zip    # Wrymstooth 1.17B
@@ -164,3 +164,8 @@ AllowedPrefixes:
 
     # trawzifieds LOTD
     - https://mega.nz/#!ghAWiQbD!PIq-mZN3Y3i6k2ounsPt41CZ6hqEMKvsWnMsuFSFrZg # trawzifieds Finishing Line Files
+
+    # RoH - GAT Edition
+    - http://www.mediafire.com/file/tgnr65718bx82er/Danika%20the%20Warrior%20Woman%20SE.7z  # Danika the Warrior Woman
+    - https://mega.nz/#!hw5CCIQA!KkuyqmRXUD_thmsy_TQ2dHZbJFK0GY-UiGm7TQ_IWpk                # CGO zEdit Patcher
+    - https://drive.google.com/file/d/0B2VgBVA9jE6RaFNyZURxa3JXUjQ/view                     # The Ultimate Dodge Mod


### PR DESCRIPTION
This version of danika the warrior woman is hosted off nexus for... reasons?  The author posted it in a sticky on nexus.
TUDM is open source
CGO zEdit Patcher is linked in sticky at top of CGO (unlocked grip) nexus page
DDL DLL 1.5.80 is no longer available;  bumped to 1.5.97