### PR TITLE
Update ServerWhitelist.yml

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -188,6 +188,7 @@ AllowedPrefixes:
     
     # Wojo
     - http://www.lostspires.com/misc/thelostspiresv14.zip # Lost Spires
-    - http://download1839.mediafire.com/1yribciv6rvg/umkuymap6mrcy58/TD_Lower_Clutter_v1.1.7z # Lower Clutter Retexture
-    - http://download1466.mediafire.com/cjthhiqrjqig/y7qlopk3w0rv7el/TD_Middleclass+v+3.1.7z # Middle Class Retexture
-    - http://download1097.mediafire.com/i1vinm933qqg/5knlyey62zrmhf8/TD_Upperclass+v+3.1.7z # Upper Class Retexture
+    - https://www.mediafire.com/file/umkuymap6mrcy58/TD_Lower_Clutter_v1.1.7z/file # Lower Clutter Retexture
+    - https://www.mediafire.com/file/y7qlopk3w0rv7el/TD_Middleclass_v_3.1.7z/file # Middle Class Retexture
+    - https://www.mediafire.com/file/5knlyey62zrmhf8/TD_Upperclass_v_3.1.7z/file # Upper Class Retexture
+    - http://tamriel.ru/7roadsmod/Knights_Patch_02.zip # Living and the Dead/Knights of the Nine Compatibility Patch


### PR DESCRIPTION
Changed the MediaFire links to be used for manual downloads, since WJ doesn't handle MediaFire too great at the moment. Also added a small patch.