### PR TITLE
Add https://download.fliggerty.com to whitelist

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -229,6 +229,7 @@ AllowedPrefixes:
     - http://www.loverslab.com
     - https://www.loverslab.com
     - https://spacedock.info/
+    - https://download.fliggerty.com
 
     # Common files
     - https://archive.org/download/wyrmstooth1.18SSE/Wyrmstooth%201.18%20SSE.zip    # Wyrmstooth 1.18SE


### PR DESCRIPTION
Many popular Morrowind mods are housed on Great House Fliggerty and cannot be uploaded elsewhere due to the authors set permissions.