### PR TITLE
Add Google Drive ID for Vanilla Lod

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -214,6 +214,9 @@ GoogleIDs:
     - 17bLByYNC9RAoDhvZNU6ljhSRHleVk8gF # Tsukirim DynDoLOD
     - 18fIuGGRs_-RUU-6MeRLaoS1ew3kU0qfC # Tsukirim Grasscache
     - 1SaMrbLfN8QJ5pkhCBsPKNyMm_0h-Amyv # Tsukirim LodGen
+
+    # Viva New Vegas
+    - 1lznQ6JB8093BUrLsXR5jKK_x-INB7fX2 # Vanilla LOD
     
 AllowedPrefixes:
     - https://wabbajack.b-cdn.net/  # Wabbajack CDN


### PR DESCRIPTION
LOD generated through FNVLODGen for use with vanilla textures that allows for objects to be seen from much farther away.