### PR TITLE
Add unofficial backup FNV Geck

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -340,6 +340,7 @@ AllowedPrefixes:
     - https://www.mediafire.com/file/fd0d6qj78lpjbas/AllGUD_AlternateTextureModelsplosion_-_Fixed.pas/file # AllGUD Fixed Script
     - https://mega.nz/#!BZhlVCAJ!s-GqqbnJlZDvCLPiRw1Wm1EWGqMQCuh4CR8Zzn8POM4 #FO4LODGen Resources 
     - https://cdn.bethsoft.com/fallout/nv/geck/GECK_NVE_v1.4.zip # FNV GECK
+    - http://geckwiki.com/images/c/ca/GECK_NVE_v1.4.7z # Backup FNV GECK
     
     # Oblivion Files
     - https://mega.nz/#!HlxQGIjK!n6rJOhznkuBwVVey7ApxOW8QHjkMx0P6wHiZlqCisgE # Insanity's Improved Armory Compilation


### PR DESCRIPTION
Since Bethesda's hosting of FNV Geck regularly breaks, here is an unofficial backup hosted by C6, Karut, etc.