### PR TITLE
Living Skyrim Baka Edition LOD Outputs

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -673,6 +673,10 @@ AllowedPrefixes:
     - https://mega.nz/file/3pJWBSaZ#ocSRVThRXEpp9bIz9ZLFsuOf59pucQXUjED6hI1p0E8 # SSELODGen
     - https://mega.nz/file/rsQCRIZJ#Gcznk7qOr7ZugmEM7s3P5_42GeoakE-UFnq1p_lG2Cs # DynDOLOD Output
     
+    # Living Skyrim Baka Edition LODs (ForgottenGlory & Hajo)
+    - https://mega.nz/file/s80mDRJR#XBFiId-dOJbo1EYFuYS79XnSckXHNm9kSlIpRI5ixKA # DynDOLOD Output
+    - https://mega.nz/file/dhsQ0biK#jhTTjA3tAuZrg12xDgjKQSI0qZkg7h5eCQFy0G0YTdg # SSELODGen Output    
+    
     # Wyrmstooth LE
     - https://archive.org/download/wyrmstooth1.18/Wyrmstooth%201.18.zip # Wyrmstooth LE
     


### PR DESCRIPTION
Added DynDOLOD and SSELODGen Output links for Living Skyrim Baka Edition, my own fork of the LS3 modlist.