### PR TITLE
Update ServerWhitelist.yml for SkyFurry 1.3 release

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -401,7 +401,8 @@ GoogleIDs:
     # SkyFurry
     - 1sKJDRgnbq1Qc2myTJzx0gqE668d4weVF # SAM HPC for SkyFurry
     - 1Z6L9SFYPYm_lJ5wtM8fcxYZ6NNrOrXxH # SAM RM Morphs for SkyFurry
-    - 1KE4F2SelfQT-admcHq7macPOE0MMyh_E # Male Body for SkyFurry
+    - 1KE4F2SelfQT-admcHq7macPOE0MMyh_E # Male Body for SkyFurry 1.2
+    - 1m1eyNbm8RfnrtYpcPIDgho4VhKLRFVdz # Male Body for SkyFurry 1.3
     - 1vPe4DxufKEacaQMkMtj9fAnywZ6acPtG # YiffyAge of Skyrim release 13
 
     # PROJECT Skyrim


### PR DESCRIPTION
Added Google drive link to Male Body for SkyFurry 1.3, updated description of previous Google drive link to Male Body for SkyFurry 1.2.
Main SkyFurry mod page including updated Google drive link for SkyFurry Part 2 (AKA Male Body) at https://www.nexusmods.com/skyrimspecialedition/mods/68672