### PR TITLE
Update ServerWhitelist.yml for SkyFurry 1.3.1

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -440,6 +440,7 @@ GoogleIDs:
     - 1Z6L9SFYPYm_lJ5wtM8fcxYZ6NNrOrXxH # SAM RM Morphs for SkyFurry
     - 1KE4F2SelfQT-admcHq7macPOE0MMyh_E # Male Body for SkyFurry 1.2
     - 1m1eyNbm8RfnrtYpcPIDgho4VhKLRFVdz # Male Body for SkyFurry 1.3
+    - 1h6MUqjd6yWQgoyWSGwuRpgQjbCMnmyrY # Male Body for SkyFurry 1.3.1
     - 1vPe4DxufKEacaQMkMtj9fAnywZ6acPtG # YiffyAge of Skyrim release 13
 
     # PROJECT Skyrim


### PR DESCRIPTION
Updating ServerWhitelist.yml for SkyFurry Male body 1.3.1, corresponding with updated version of SkyFurry 1.3.1 hosted on nexus mods here:  https://www.nexusmods.com/skyrimspecialedition/mods/68672