### PR TITLE
Update ServerWhiteList.yml for SkyFurry 1.3.1

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -442,6 +442,7 @@ GoogleIDs:
     - 1KE4F2SelfQT-admcHq7macPOE0MMyh_E # Male Body for SkyFurry 1.2
     - 1m1eyNbm8RfnrtYpcPIDgho4VhKLRFVdz # Male Body for SkyFurry 1.3
     - 1h6MUqjd6yWQgoyWSGwuRpgQjbCMnmyrY # Male Body for SkyFurry 1.3.1
+    - https://drive.google.com/file/d/1h6MUqjd6yWQgoyWSGwuRpgQjbCMnmyrY # manualURL link to Male Body for SkyFurry 1.3.1
     - 1vPe4DxufKEacaQMkMtj9fAnywZ6acPtG # YiffyAge of Skyrim release 13
 
     # PROJECT Skyrim


### PR DESCRIPTION
Adding manualURL download for SkyFurry Male Body 1.3.1 due to issues with directURL download grabbing Google virus scan info HTML page instead of correct file.