### PR TITLE
Update ServerWhitelist.yml

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -167,6 +167,7 @@ GoogleIDs:
     - 11T5k_CAlFMoN9uwWuyRhdRprV7pGHb7n # Cosmofujia's ER Legendary Weapons
     - 1DZMKj4B8FUeeAmhv7j3wA6yFQ2kg8w2w # Olivier Kenjutsu Sword MCO
     - 1Idn2Y-_dTCoRtUrohb0zNS3Nea2CfheY # Olivier Kenjutsu Greatsword MCO
+    - 1PigoPEWDTgS66jKtYaeW_qDHHTXJ88wQ # [Dint999] BDOR Hairs SSE 0.14
     
     # Total Skyrim Overhaul files
     - 144op2Nq9_p5dlwpdQ3uIHB-RN0Zx11Hc # Dobart


### PR DESCRIPTION
New version of Dint BDOR hair pack. Public link in his Discord server. (It even has disclaimer "public" in the announcement.) Version 0.13 is whitelisted and it was discussed in the WJ Discord chat for 0.13 PR that its fine.

Youtube showcase has the Discord link: https://www.youtube.com/watch?v=ZoPCMm1NwzI