### PR TITLE
Update ServerWhitelist.yml

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -241,6 +241,7 @@ GoogleIDs:
     - 1EbMYbkRsvxu_sbqzYuxKYxMbj7WL6hoE # Blood Raven
     - 1C5Jv4b-9KT-CmQwtgx4KWdnl3or-p4Ym # All is Gold
     - 1qY8Xe8LAF63m3UVJM58xVj1TOTd3uR-l # MCO Sprint Attack Stamina Fix by Maxsu
+    - 1vWIbrO7nHgW27HbjXBxMjuM3sJDitAF9 # [Dint999] BDOR Hairs SSE 0.15
     
     
     


### PR DESCRIPTION
New version of Dint BDOR hair pack. Public link in his Discord server. (It even has disclaimer "public" in the announcement.) Version 0.13 and 0.14 are whitelisted and it was discussed in the WJ Discord chat that dint's bdor hair packs are fine to whitelist.

Youtube showcase has the Discord link: https://www.youtube.com/watch?v=ZoPCMm1NwzI