### PR TITLE
Whitelisting Modding Guild as global site

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -561,6 +561,7 @@ AllowedPrefixes:
     - https://c6-dev.github.io # c6 (xNVSE Dev)'s Github subdomain
     - https://audixas.github.io # Audixas (Guide and Mod author) Github subdomain
     - https://www.skyrim-guild.com/ # Modern Combat Skyrim stuff mostly. Distar/Adri host here
+    - https://www.modding-guild.com/ # skyrim-guild renames to modding-guild
     - https://valheim.thunderstore.io/ # Valheim based modding, includes more, isolated mods that aren't hosted on Nexus Mods.
     - https://geckwiki.com/ # New Vegas Creation Kit
     - https://gamebanana.com/ # Primary Persona modding site


### PR DESCRIPTION
Skyrim Guild is going to rename to Modding Guild. Although at the moment, it seems the old links are still working so this is a preventive measure to already ensure mod authors can edit their .metas accordingly.
