### PR TITLE
Update ServerWhitelist.yml

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -1692,21 +1692,7 @@ AllowedPrefixes:
     
     
     # TRUE VEGAS TTW
-    - http://www.mediafire.com/file/qucw6ib5uk22boj/AnNPCOverhaul.rar/file #Dragbodys An NPC Overhaul 
-    - http://www.mediafire.com/file/xvt9rte2yk9stc1/BrotherhoodReforged.rar/file #Dragbodys Brother of Steel Reforged 
-    - http://www.mediafire.com/download/omka83jygvx0qon/NCRUltimateOverhaul.rar/file # Dragbodys NCR Ultimate Overhaul 
-    - http://www.mediafire.com/file/4hpy776vizmmh2z/GreaterKhansOverhaul.rar/file # Dragbodys Greater Khans
-    - http://www.mediafire.com/file/83zg3u81ibkad4t/PowderGangerOverhaul.rar/file # Dragbodys Powder Ganger Overhaul 
-    - http://www.mediafire.com/file/j7xthhc3rqg8n2i/BoomersGoBoom.rar/file # Dragbodys Boomer Overhaul
-    - http://www.mediafire.com/file/5h8tl8s2urhbka2/WeAreLegionBETA.rar/file # Dragbodys We Are Legion  
-    - https://www.mediafire.com/file/7vxmk2o1u824l5k/TuxekLilBitsV2.1.7z/file # Tuxek Lil Bits  
-    - https://eddoursul.win/download/247 # Enhanced Vision
-    - https://eddoursul.win/download/378 # Bottle Rinse Repeat
-    - https://eddoursul.win/download/369 # Bottle Rinse Repeat TTW Patch 
-    - https://www.moddb.com/downloads/start/236022 # Darnified UI TTW
-    - https://cdn.discordapp.com/attachments/267355049666019329/1003041304252534814/TTW_3.3.2_Hotfix.zip # TTW 3.3.2 Hotfix
-    - https://eddoursul.win/download/1066 # Hoodwink 3.3.2 Patch
-    - https://mega.nz/file/EAJDTDBb#WCKPY_YyLth24qImJmkt4rydW2-Jrgbz2AJ4gOYzjgA # LODGEN .97
+    
     
     # iAmMe's WoD
     - https://www.mediafire.com/file/kfac38dni6d53rp/MiscHairstyle1.6_by_Atherisz.7z # Misc Hairstyles v1.6 by Atherisz


### PR DESCRIPTION
Removed all whitelists from True Vegas TTW category as they are no longer used by us, are dead links, or are not used by other lists