### PR TITLE
Update ServerWhitelist.yml

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -522,6 +522,9 @@ GoogleIDs:
 
     # NEFARAM
     - 1Ts0sQz3hDxhCeS_LUnXJQFuws_qbw9YQ # Dint Hair Pack 02 SE 1.10
+
+    # Skyrim Legendary Edition WD
+    - 114RS5tS9B7az2i-DI6tJyyCFyQLZcYqO # SexLab Aroused Redux V28b Modified by BakaFactory (for LE)
     
 AllowedPrefixes:
     - https://build.wabbajack.org/authored_files/direct_link # Direct Links, mostly for testing


### PR DESCRIPTION
Please could you add "SexLabAroused Redux V28b LE Modified by BakaFactory(2020 11 17)).7z"

I am building a Wabbajack list for Skyrim LE. The SSE version of this file is already included in the whitelist, but not the LE version.

Link is: https://drive.google.com/file/d/114RS5tS9B7az2i-DI6tJyyCFyQLZcYqO

The mod is by factoryclose. They don't have a LL page dedicated to this mod but they do link to the Google Drive file in one of their other mods, BaboDialogue, as a required LE mod as seen in: 

https://www.loverslab.com/files/file/17496-babodialogue/

Many thanks