### PR TITLE
Add SkyBirds and Birds Of Skyrim

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -1896,3 +1896,7 @@ AllowedPrefixes:
 
     # Fallout Anomaly
     - https://storage.icestormng-mods.de/s/Jp9nfE8g4iQmyy8/download?path=%2F1.2%2FRelease&files=IceStorms%20Hair%201.2.7z&downloadStartSecret=s0bm398ive # Haircut mod by IceStormNG
+
+    # Steve40 Mods
+    - https://www.dropbox.com/s/3tlt2734s3r97hg/skyBirds%20SSE%20Edition%20v1.20.7z?dl=1 # SkyBirds SSE 1.2
+    - https://www.dropbox.com/s/0zmfolkcxrpv5d0/Birds%20of%20Skyrim%20SSE%20Edition%202.7.7z?dl=1 # Birds Of Skyrim SSE 2.7


### PR DESCRIPTION
Adding the official link to SkyBirds and Birds of Skyrim mods by Steve40.
He had them linked in his Nexusmods profile page, but since Nexusmods moved to the newer forum software, all profile pages are gone. Web archive still has a copy, so you can confirm its legit: https://web.archive.org/web/20230818022652/https://www.nexusmods.com/fallout4/users/3463396?tab=about+me