### PR TITLE
Added Tyddy's HQ and UHQ Landscape Textures.

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -1896,3 +1896,7 @@ AllowedPrefixes:
 
     # Fallout Anomaly
     - https://storage.icestormng-mods.de/s/Jp9nfE8g4iQmyy8/download?path=%2F1.2%2FRelease&files=IceStorms%20Hair%201.2.7z&downloadStartSecret=s0bm398ive # Haircut mod by IceStormNG
+
+    # Kezyma's Morrowind Remastered
+    - https://www.fullrest.ru/files/tyd_landscape-texture_compilation_1/files?fid=4454
+    - https://www.fullrest.ru/files/tyd_landscape-texture_compilation_1/files?fid=4453


### PR DESCRIPTION
The MQ textures are already in the whitelist, but HQ and UHQ are both missing. I'm planning on using them in an alternative version of Morrowind Remastered, so requesting to add them now!