### PR TITLE
Update BG3 Mods links

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -1959,11 +1959,9 @@ AllowedPrefixes:
     - https://www.mediafire.com/file/9e000wxv51i4afw/iAm_fixes_Vominheim.rar/file # iAm_fixes_Vominheim ( Permission to uplaod )
     - https://www.mediafire.com/file/g1ei06w0wd6hlsd/[Cloud]+Hex+Tenebris+-+3BA.zip/file # -3BA version
 
-    # Faerun Enhanced - BG3 (from zino/Alvadus)
-    - https://www.patreon.com/file?h=100667856&i=18177410 # MANTIS' PRESET COLLECTION VOL 1
-    - https://www.patreon.com/file?h=99267100&i=17877080 # AEMONDV1 (NON REPLACERS) - OLD TEXTURES
-    - https://www.patreon.com/file?h=99266668&i=17907185 # RHAENYRAV1 (NON-REPLACERS)
-    - https://www.patreon.com/file?h=99268439&i=17987815 # FREYJA (NON-REPLACERS)
-    - https://www.patreon.com/file?h=99269567&i=17878078 # DAENERYS (NON-REPLACER)
-    - https://www.patreon.com/file?h=99270441&i=17877704 # DAEMON (NON-REPLACERS)
-    - https://www.patreon.com/file?h=99742734&i=17958548 # BONNIBEL (NON-REPLACER)
+    # Faerun Enhanced - BG3 (from zino)
+    - https://drive.google.com/file/d/1pofLcmBatfn9H5xfXgMXu-xwEoR4DZHz/view?usp=sharing # MANTIS' OC PRESETS VOL. I - BG3 Preset Collection
+    - https://www.patreon.com/file?h=102509958&i=18601507 # MANTIS' GAME OF THRONES PRESETS - BG3 Preset Collection
+    - https://www.patreon.com/file?h=102510023&i=18604004 # MANTIS' WITCHER INSPIRED PRESETS - BG3 Preset Collection
+    - https://drive.google.com/file/d/1PNeTExH0tEeaOPr4JocXCKff23iTD365/view?usp=sharing # MANTIS' HOUSE OF THE DRAGON PRESETS - BG3 Preset Collection
+    - https://www.patreon.com/file?h=102506271&i=18535437 # MANTIS' LORD OF THE RINGS PRESETS - BG3 Preset Collection


### PR DESCRIPTION
I replaced the mods I had in the whitelist from before with new links and complete versions with additional ones, these are face presets for BG3

- https://drive.google.com/file/d/1pofLcmBatfn9H5xfXgMXu-xwEoR4DZHz/view?usp=sharing # MANTIS' OC PRESETS VOL. I - BG3 Preset Collection
- https://www.patreon.com/file?h=102509958&i=18601507 # MANTIS' GAME OF THRONES PRESETS - BG3 Preset Collection
- https://www.patreon.com/file?h=102510023&i=18604004 # MANTIS' WITCHER INSPIRED PRESETS - BG3 Preset Collection
- https://drive.google.com/file/d/1PNeTExH0tEeaOPr4JocXCKff23iTD365/view?usp=sharing # MANTIS' HOUSE OF THE DRAGON PRESETS - BG3 Preset Collection
- https://www.patreon.com/file?h=102506271&i=18535437 # MANTIS' LORD OF THE RINGS PRESETS - BG3 Preset Collection