### PR TITLE
Added Fusion Girl Body replacer for Fallout 4

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -2106,3 +2106,6 @@ AllowedPrefixes:
     # N.Y.A 5.2
 
     - https://ss-uploads-prod.b-cdn.net/uploads_v2/users/156627/posts/1392029/e9d678a1-c21d-4c47-a74c-d571eaeb3224.7z # Baka SLAL 7.00
+
+    # Fusion Girl Body replacer Fallout 4
+    - https://www.mediafire.com/file/1vljtubz9nzwr1h/FusionGirl-0223.7z/file # Fusion Girl Female Body Replacer (FG)


### PR DESCRIPTION
Fusion Girl Body lives on Lover's Lab and is a very popular alternative to CBBE. The link for download is on Media Fire.

I'm requesting to add it as I need it for my modlist I'm working on.

Link To FG Body on Loverslab
https://www.loverslab.com/files/file/18238-zex-fusion-girl/