### PR TITLE
Add remaining Steve40 mods to ServerWhitelist.yml

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -2015,10 +2015,27 @@ AllowedPrefixes:
     - https://mega.nz/file/bf4VhaCb#WF35skdDrj-yQu_tcdrJ2NGQj0vpNbywutN5tQ2mQ5w # RyanReos Bladedancer
     - https://mega.nz/file/CCoVBSKZ#AKeC07-8IppzNieVBxjuM7c4riJnSHigSZHUjV68yjM # RyanReos High Priestess
 
-    # Steve40 Mods
+    # Steve40 Mods - Skyrim
     - https://www.dropbox.com/s/3tlt2734s3r97hg/skyBirds SSE Edition v1.20.7z?dl=1 # SkyBirds SSE 1.2
+    - https://www.dropbox.com/scl/fi/h0d5tr2mokzw0ryehmdxg/skyBirds-Airborne-Perching-Birds-23771-v0-931.rar?dl=1 # SkyBirds LE v0.931
     - https://www.dropbox.com/s/0zmfolkcxrpv5d0/Birds of Skyrim SSE Edition 2.7.7z?dl=1 # Birds Of Skyrim SSE 2.7
-    - https://www.dropbox.com/s/iv7wov5tdmslcin/Birds and Flocks SSE Edition v2.1.7z?dl=1 # Birds and Flocks 2.1.7
+    - https://www.dropbox.com/s/iv7wov5tdmslcin/Birds and Flocks SSE Edition v2.1.7z?dl=1 # Birds and Flocks SSE 2.1.7
+
+    # Steve40 Mods - Fallout 4
+    - https://www.dropbox.com/scl/fi/fd3idtv30dfgm7649myye/CWSS-Redux-v4.011.7z?dl=1 # CWSS v4.011
+    - https://www.dropbox.com/scl/fi/wi8etvieljcedzzdw4yd2/CWSS-and-GetDirty-Compatibility-Patch.7z?dl=1 # CWSS v4.011 + Get Dirty v1.3 Compatability Patch
+    - https://www.dropbox.com/scl/fi/mq9xt28vncvhc03defb2p/Universal-Working-Bathroom-Fixtures-CWSS-and-DLCs-v1.8.7z?dl=1 # Universal Working Bathroom Fixtures (CWSS and DLCs) v1.8
+    - https://www.dropbox.com/scl/fi/s40expsvgyb8fn2uqif3e/Swinging-Meat-Bags-v1.4.1.7z?dl=1 # Swinging Animated Meat Bags v1.4.1
+    - https://www.dropbox.com/scl/fi/ultl2x4kdqwvq5mse2z5k/Better-Cooking-Stations-v2.1.7z?dl=1 # Better Cooking Stations v2.10
+    - https://www.dropbox.com/scl/fi/qev8gvs58aytkef2w0vml/Better-Cooking-Stations-v2.02-Mojave-Imports-patch-20170216.7z?dl=1 # Better Cooking Stations v2.02 - Mojave Imports Patch
+    - https://www.dropbox.com/scl/fi/wbdrdc18rme2dmyzh090h/Enhanced-Flickering-Firelight-v2.1.7z?dl=1 # Enhanced Flickering Firelight v2.1
+    - https://www.dropbox.com/scl/fi/w2f4xrhm9nzac25rbalh9/Better-High-Tech-Lights.7z?dl=1 # Better High Tech Lights
+    - https://www.dropbox.com/scl/fi/7lmly9g0sqlxz0nd17taf/BurningCampfiresThatHurt-v1.01ND.7z?dl=1 # Burning Campfires That Hurt v1.01 - No NPC Damage Version
+    - https://www.dropbox.com/scl/fi/4wj8ccs0fhzlpa3o8qemi/BurningCampfiresThatHurt-v1.0-reduced-NPC-damage.7z?dl=1 # Burning Campfires That Hurt v1.00 - Reduced NPC Damage Version
+    - https://www.dropbox.com/scl/fi/wtsoj1ov35hq2ny6lvmbh/Port-A-Diner-Perfection-v2.3.7z?dl=1 # Port-A-Diner Perfection v2.3
+    - https://www.dropbox.com/scl/fi/7tozrq3892p956y9hjzac/Better-Homing-Beacon.rar?dl=1 # Better Homing Beacon
+    - https://www.dropbox.com/scl/fi/ndfbjian5cigq2tpav7t6/Better-Artillery-Signal-Flares-vanilla-weight-version-11203-1-1.7z?dl=1 # Better Artillery Signal Flares v1.1 - Vanilla Weight
+    - https://www.dropbox.com/scl/fi/xw0eej5zpjae80e90j4vz/Anonymous-Artillery-Fire.7z?dl=1 # Anonymous Artillery Fire (Optional Script for Better Artillery Signal Flares)
     
     # The Nico Experience
     - https://mega.nz/file/zHRDhQBK#yJ9vhNaNwqQpUzHPCcR0n2UrpOF1oG3AJL4FL_MYHQw # BDOR Complete Collection by Kirax


### PR DESCRIPTION
Add the remainder of mod archives listed on modder Steve40's old Nexus account [(link)](https://next.nexusmods.com/profile/steve40), separated between Skyrim and Fallout 4 mods. 