### PR TITLE
Update Nuka-Ride links in ServerWhitelist.yml

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -993,12 +993,6 @@ AllowedPrefixes:
     # Living Skyrim Baka Edition LODs (ForgottenGlory & Hajo)
     - https://mega.nz/file/s80mDRJR#XBFiId-dOJbo1EYFuYS79XnSckXHNm9kSlIpRI5ixKA # DynDOLOD Output
     - https://mega.nz/file/dhsQ0biK#jhTTjA3tAuZrg12xDgjKQSI0qZkg7h5eCQFy0G0YTdg # SSELODGen Output    
-
-    # FO4 Survivor Slave
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q                 # Nuka Ride 6.4.7
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q/folder/ylhRWDAB # Nuka Ride - Textures for the Girls 1.1
-    - https://mega.nz/folder/epZxGIRR#-V3hKLRvXlXWKfwF8zr-Sw                 # Commonwealth Slavers 2.4.6
-    - https://mega.nz/folder/epZxGIRR#-V3hKLRvXlXWKfwF8zr-Sw/folder/39gHBaIQ # Commonwealth Slavers - Voices 1.02
     
     # Wyrmstooth LE
     - https://archive.org/download/wyrmstooth1.18/Wyrmstooth%201.18.zip # Wyrmstooth LE
@@ -1953,6 +1947,10 @@ AllowedPrefixes:
     - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/SpIXTTqa # Nuka Ride - Textures for the Girls
     - https://mega.nz/file/viIQkKQZ#qABDruPixRI0B-pb9vWV2u-uf2Gt7pfGq9zWlLJeDgk # Nuka Ride - The Previous Girl
     - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/HlQ3WbZJ # High Heel Sounds Remake by Axary
+
+    # Commonwealth Slavers
+    - https://mega.nz/folder/epZxGIRR#-V3hKLRvXlXWKfwF8zr-Sw/file/SwQABb7C # Commonwealth Slavers 2.6.8c
+    - https://mega.nz/folder/epZxGIRR#-V3hKLRvXlXWKfwF8zr-Sw/file/LxxBDZiD # Commonwealth Slavers Voices 1.08
     
 
     # More of caco's Cringe

--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -1090,8 +1090,9 @@ AllowedPrefixes:
     - http://www.mediafire.com/file/iztz7iidy6djz1e/MoreHairstyles-Beards.rar/file # MoreHairstyles-Beards
     - http://www.mediafire.com/file/3miqb8c0vy35zs0/Misc_Hairstyles_Physics_1.1.rar/file # Misc Hairstyles Physics 1.1
     
-    # FO4NSFW
-    - https://mega.nz/file/OJlhjAIY#OOXFht6D-oR7t64YS07U2DSqVEG15fBSxst0iWY7M1U # DeviousDevicesFO4
+    # Devious Devices for Fallout 4
+    - https://mega.nz/file/OJlhjAIY#OOXFht6D-oR7t64YS07U2DSqVEG15fBSxst0iWY7M1U # Devious Devices 2.0
+    - https://mega.nz/file/QuYGCAoT#kLlwGQTHSW0g4M8h3VMPqNrH9Eenul9TCkbuhNRitQI # Devious Devices 2.0 RC9
     
     # SkyrimVR:Dragons Die Twice 
     - https://www.patreon.com/file?h=33799784&i=5130771

--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -1909,7 +1909,6 @@ AllowedPrefixes:
     # Parabellum by cacophony
     - https://mega.nz/file/8zBCGJhI#apyUCBuGuZQ_5Va7iby02AEybzKLE25tSEcGML1C-Yg # Vtaw Wardrobe 8 2K v1.0
     - https://mega.nz/file/1E8RHZ7Z#SWxMF3lT-4mfUYRgrlq1hhokeS_z1fplmiZJvaP1JNY # Vtaw Wardrobe 8 BodySlides
-    - https://mega.nz/file/QSZ2UQhQ#NiBll61rgvS8tqwO2PpP3OjfnrDds8JiYM73Sx8PqvQ # BodySlides
     - https://mega.nz/file/4J9CCYaS#7WJjKmUpo3gMuaNSX42WIfCawbJfBeNgEB01XI-YDw8 # Vtaw Lana 1.0
     - https://mega.nz/file/AE9ymaQS#te_ln4FdTQbrA9RM5z6PWfk9kGLa4edYIqCBdgLKb1E # Vtaw Lana BodySlides
     - https://mega.nz/file/IctAERAD#qSKbeEd2CQN_8Ra52zas6dtjNwoGh7PQe6HY-6JHHj0 # Vtaw Overalls 1.1
@@ -1936,47 +1935,24 @@ AllowedPrefixes:
     - https://mega.nz/file/8Ml2TJKJ#RzJpP8STFgV2m3rc5kji4gO0advbkigfgFH4zEMs2-M # Vtaw Sweet Dress BodySlides
     - https://mega.nz/file/5F10lDgC#xy83Rlfvh8Vg2oiQ3mF1_CyyEMxLVsmfhdt5E7Axzcs # Vtaw 2022 March Dress 1.0
     - https://mega.nz/file/Mc1XxI6R#c2ptTrquyRiiZe5uBgxFZmQX7lMnBmyqmuamK11dld4 # Vtaw March Dress BodySlides
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q/file/2tx0WJ5B # Nuka Ride 6.2.1
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q/file/HooF3L7J # Nuka Ride 6.2.4
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q/file/jxgACYaZ # Nuka Ride 6.3.3
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q/file/T9RUyRKR # Nuka Ride 6.3.6
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q/file/n8RgBTII # Nuka Ride 6 Bodyslide for CBBE 1.03
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q/file/HooF3L7J # Nuka Ride 6.2 BodySlide for CBBE 1.04
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q/file/T5pS1JAB # Nuka Ride 6.3 BodySlide for CBBE 1.2
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q/file/ngxSSb7C # Nuka Ride 6.3 BodySlide for CBBE 1.3
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q/file/r9gT2JYA # Nuka Ride 6.1 Voices by Axary (xVASynth ) and Kalistara (11labs) 1.0
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q/file/X15TRJya # Nuka Ride 6.3.6 Scooter HotFix
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q/file/GlhlkIZJ # Nuka Ride 6.4.0
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q/file/Kh5ChbAQ # Nuka Ride 6.4.1
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q/file/H5g2Vb5S # Nuka Ride 6.4.2
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q/file/7gggXAhQ # Nuka Ride 6.4.3
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q/file/Tgwk1QTC # Nuka Ride Main Menu
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q/file/y54VQLha # Nuka Ride 6.4.4
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q/file/PhpQAC7J # Nuka Ride 6.4.5
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q/file/HwJiBLLQ # Nuka Ride 6.4.6
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q/file/L9gg0LpI # Nuka Ride 6.4.7
-    - https://mega.nz/folder/HxwTyQiQ#P139pOMVYKfW_5GuGJqXAA/file/WxZEALzS # Nuka Ride 6.7.6
-    - https://mega.nz/folder/vlRzFIaS#CgeMqhCfNylqHPb3DmMG-Q/file/X5w3AKTA # Nuka Ride 6.3 BodySlide for CBBE 1.4
-    - https://mega.nz/folder/HxwTyQiQ#P139pOMVYKfW_5GuGJqXAA/file/qtBCzJBA # Nuka Ride 6.7 BodySlide for CBBE 1.1
-    - https://mega.nz/folder/HxwTyQiQ#P139pOMVYKfW_5GuGJqXAA/file/vxhBCahL # Nuka Ride PC Female Idles
-    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/a0RxhJBL # Nuka Ride PC Female Idles (Replaced Version)
-    - https://mega.nz/folder/HxwTyQiQ#P139pOMVYKfW_5GuGJqXAA/file/atRCBZrI # Nuka Ride Random Menus
-    - https://mega.nz/file/viIQkKQZ#qABDruPixRI0B-pb9vWV2u-uf2Gt7pfGq9zWlLJeDgk # Nuka Ride - The Previous Girl
     - https://www.mediafire.com/file/flx0mao5fn7v541/Kziitd_F*t*sh_Toolset_-_Bodyslide_1.0_Beta_1.7z/file # Kziitd Toolset BodySlides 1.0 Beta 1
-    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/XlYAlRiD # Nuke Ride 6.8.0i
-    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/G5pS3bRI # Nuka Ride 6.8 BodySlide for CBBE
-    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/akpwQILS # Nuka Ride Random Main Menu Themes 6.8
-    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/SthnQRxB # Nuka Ride Facegen for Nexgen
+
+    # Nuka Ride
+    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/345FVIyK # Nuka Ride 6.8.6
+    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/G5pS3bRI # Nuka Ride 6.8 - BodySlide for CBBE
+    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/21BhCbJT # Nuka Ride 6.8 - BodySlide for Fusion Girl
+    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/ix42nJpY # Nuka Ride 6.8 - Clone Voice Bug Fix
+    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/P5oywZwa # Nuka Ride 6.8 - Voices
+    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/CwJByJxT # Nuka Ride - AAF Prostitution XML Fix
+    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/q0Y3TB6L # Nuka Ride - Denizens of the Apocalypse Patch
+    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/SthnQRxB # Nuka Ride Facegen for NextGen
     - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/a0RxhJBL # Nuka Ride PC Female Idles
-    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/akpwQILS # Nuka Ride Random Menus 6.8
-    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/KwJW1JhB # Nuka Ride 6.8.1b
-    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/ut5wnJJI # Nuka Ride 6.8.2
-    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/W4hT3TII # Nuka Ride 6.8.3
-    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/T5ITxRhD # Nuka Ride 6.8.4 
-    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/vpoSTSpD # Nuka Ride 6.8.4 - stealth update
-    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/nhAEnBBL # Nuka Ride 6.8.4 - stealth update 2 
-    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/TwxXnKpL # Nuka Ride 6.8.5
-    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/35AVRDyI # Nuka Ride 6.8.5b
+    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/akpwQILS # Nuka Ride Random Main Menu Themes
+    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/qohj0LTQ # Nuka Ride Random Main Menu Themes
+    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/mtwD2C7R # Nuka Ride - Tesla Cannon CC Radio Compatibility
+    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/SpIXTTqa # Nuka Ride - Textures for the Girls
+    - https://mega.nz/file/viIQkKQZ#qABDruPixRI0B-pb9vWV2u-uf2Gt7pfGq9zWlLJeDgk # Nuka Ride - The Previous Girl
+    - https://mega.nz/folder/DtBHSbwA#KdRrNKOWY9Mus8hB6iSI0w/file/HlQ3WbZJ # High Heel Sounds Remake by Axary
     
 
     # More of caco's Cringe


### PR DESCRIPTION
(NSFW Mods)
Existing links for the [Nuka Ride](https://www.loverslab.com/files/file/18178-aaf-nuka-ride-a-porn-studio-mod/) mod, primarily added by PR #832 and manually committed (i think) by cacophany-wj, are now invalid, due to the folder/files not being publicly accessible anymore.

This will purge the dead links replacing them with ones for the most recent version (6.8.6), as well as adding other add-ons/patches that were not included in the original commits.

Also included [Commonwealth Slavers](https://www.loverslab.com/files/file/24429-commonwealth-slavers/) links as those were also part of the PR, though I only included updated versions of the original files.

Edit: Added a link to an unofficial update of [Devious Devices for Fallout 4](https://www.loverslab.com/topic/73925-devious-devices/page/207/#comment-4159706)