### PR TITLE
I added an alternate download link for one of the Mega files

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -2151,6 +2151,9 @@ AllowedPrefixes:
     - https://www.patreon.com/file?h=96406751&m=265878755 # _Fuse00_ArmorShadow
     - https://www.patreon.com/file?h=122295901&m=422046302 # _Fuse00_ArmorAkasha (CBBE)
 
+    # Alternate Links for Mega Files
+    - https://www.mediafire.com/file_premium/wvgl002k5nqy05h/DX_Druid_Armor_CBBE_SE_HDT-SMP.7z/file # DX Druid Armor HDT-SMP Patch
+
     # MaskedRPGFan Settings Loaders
     - https://www.patreon.com/file?h=117178497&m=386619775 # True Armor Settings Loader
     


### PR DESCRIPTION
I got permission from the author of the DX Druid Armor HDT-SMP Patch to upload and host it on Mediafire as an alternate download link from Mega. I attached a snapshot of my correspondence with them on the Nexus in case you needed proof.
![Written Permission](https://github.com/user-attachments/assets/7e3fb736-6739-4e16-8b5a-1e015e34d9e6)
