### PR TITLE
Add FNV Mods for WSG + SALVO Wabbajack

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -204,6 +204,8 @@ GoogleIDs:
     - 1_CGZCvkqNp5_opZWf7KMew2vY4w2ncP7 # HDT-SMP Thalmor Ceykynd Armor
     - 13Ar4a56geT1wjeogGfD6ipMTR26Wpunq # HDT-SMP Thalmor Ceykynd Armor 3BA Patch
     - 1igWlujbALTf1K-TenB08imC4L-q9U-ME # HDT-SMP Thalmor Ceykynd Armor HIMBO Patch
+    - 1J9uqGoln_nMpiYrABg7rFcTafDXScehp # Atomic Audio Overhaul AiO - FNV / TTW
+    - 1QNIIVjm-thojuxaCbqdhNTP8BA3kmFbB # Simple Maps - TTW Compressed - TTW
 
     # Total Skyrim Overhaul files
     - 144op2Nq9_p5dlwpdQ3uIHB-RN0Zx11Hc # Dobart


### PR DESCRIPTION
Updating google ids whitelist to allow for Simple Maps TTW Compressed as part of the Wasteland Survival Guide:

https://wastelandsurvival.guide/docs/ui#simple-maps

Additionally adding the Atomic Adio AiO drive to expand FNV music from Sal's guide: https://salamand3r.fail/salvo/salsa-aural-bliss