### PR TITLE
Update ServerWhitelist.yml

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -629,6 +629,9 @@ GoogleIDs:
     # Nymphs Savage World Modlist
     - 1r9W-XGWVplFyhUKfmkBWXdCidHnPlNrK # TalesOfStar
     - 1CS6vgJT7-YIFXMi0UrtlOo7oCdVcUHy3 # Nocturne Enchantress outfit HDT SMP CBBE BodySlide
+
+    # Mojave Express Wabbajack
+    - 11mUAG8U0jrohgKy5rZlWZA5D4eswrakz # Tammer's NIF-Bashed Armor Mega-Pack v6.0.1
     
 AllowedPrefixes:
     - https://build.wabbajack.org/authored_files/direct_link # Direct Links, mostly for testing


### PR DESCRIPTION
To add [Tammer's NIF-Bashed Armor Mega-Pack v6.0.1](https://fallout.firedrakecreative.com/doku.php?id=armor).

I noticed the older versions have already been added https://github.com/wabbajack-tools/opt-out-lists/pull/850 and https://github.com/wabbajack-tools/opt-out-lists/pull/852. 