### PR TITLE
Update ServerWhitelist.yml

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -2270,3 +2270,7 @@ AllowedPrefixes:
    
     # [Skyrim] Flying Air Balloons
     - https://www.patreon.com/file?h=111649008&m=421429268
+
+    # Telsera 
+    - https://mega.nz/file/FklVwSaD#VUFozsvMY6vBD5ah8VlbMi8UDhlNJYsrp7pERvJ4WvM # OSexAttire AE 0000 .zip
+


### PR DESCRIPTION
Hello! I was looking to request adding OSex: Attire 0000 for Skyrim AE/SE to the Skyrim SE list Telsera. The site is down currently located at https://legendofceo.com/osex/ however through the Wayback Machine ( https://web.archive.org/web/20250826155850/https://legendofceo.com/osex/ ) you can view the respective page and terms of Ceo. The link for OSex Attire AE listed via the website through Wayback machine leads to this file hosted via Mega: https://mega.nz/file/FklVwSaD#VUFozsvMY6vBD5ah8VlbMi8UDhlNJYsrp7pERvJ4WvM ( OSexAttire AE 0000 .zip ) which contains the file I was interested in the Whitelist for. This is my first time regarding Whitelist inquires, so my apologies ahead of time if this was incorrect formatting.