### PR TITLE
Update ServerWhitelist.yml

### DIFF
--- a/ServerWhitelist.yml
+++ b/ServerWhitelist.yml
@@ -314,6 +314,8 @@ GoogleIDs:
     - 1bOXXLhHhGKqCXSay7uWq4VaSxiVBZoGx # Smooth Motion Pack SE 4.0 FIX1
     - 1myIPhGdvGGxG2WQizNPdWcfapbNE0wgT # Horses Revamped SE
     - 1CcVfHEFRNb5xwZVKCCTROxqaY8cd2fLW # Smooth Motion Pack SE Olivier Jump
+    - 10gK0rB88FVipRp0baTLwJWXjR48xXxya # vanaheimr PBR AIO
+    - 1y_-_n_2i3pDnnYCReb7_uMbxxHlPRm0P # vanaheimr caves
     
     # Bevilex files
     - 16xoabvyuMXIV6x_HR3NjZZW8zsfUkgfA # Oblivion Reloaded 7.0 PRESET


### PR DESCRIPTION
vanaheimr PBR AIO from his Discord, wont be required when full nexus release but for now will just use the gdrive links